### PR TITLE
:sparkles: Add missing MTR targets

### DIFF
--- a/resources/targets.yaml
+++ b/resources/targets.yaml
@@ -78,51 +78,9 @@ items:
       imagepath: images/multiply.svg
       choice: true
       labels:
-        - name: camel:3.0
+        - name: camel:3
           label: konveyor.io/target=camel3
-        - name: camel:3.1
-          label: konveyor.io/target=camel3
-        - name: camel:3.2
-          label: konveyor.io/target=camel3
-        - name: camel:3.3
-          label: konveyor.io/target=camel3
-        - name: camel:3.4
-          label: konveyor.io/target=camel3
-        - name: camel:3.5
-          label: konveyor.io/target=camel3
-        - name: camel:3.6
-          label: konveyor.io/target=camel3
-        - name: camel:3.7
-          label: konveyor.io/target=camel3
-        - name: camel:3.8
-          label: konveyor.io/target=camel3
-        - name: camel:3.9
-          label: konveyor.io/target=camel3
-        - name: camel:3.10
-          label: konveyor.io/target=camel3
-        - name: camel:3.11
-          label: konveyor.io/target=camel3
-        - name: camel:3.12
-          label: konveyor.io/target=camel3
-        - name: camel:3.13
-          label: konveyor.io/target=camel3
-        - name: camel:3.14
-          label: konveyor.io/target=camel3
-        - name: camel:3.15
-          label: konveyor.io/target=camel3
-        - name: camel:3.16
-          label: konveyor.io/target=camel3
-        - name: camel:3.17
-          label: konveyor.io/target=camel3
-        - name: camel:3.18
-          label: konveyor.io/target=camel3
-        - name: camel:3.19
-          label: konveyor.io/target=camel3
-        - name: camel:3.20
-          label: konveyor.io/target=camel3
-        - name: camel:3.21
-          label: konveyor.io/target=camel3
-        - name: camel:4.0
+        - name: camel:4
           label: konveyor.io/target=camel4
     - uuid: e66a777a-ad09-4db8-b7e9-7217a03b4b92
       name: Azure

--- a/resources/targets.yaml
+++ b/resources/targets.yaml
@@ -76,6 +76,7 @@ items:
       name: Camel
       description: A comprehensive set of rules for migration to Apache Camel 3 and 4.
       imagepath: images/multiply.svg
+      choice: true
       labels:
         - name: camel:3.0
           label: konveyor.io/target=camel3

--- a/resources/targets.yaml
+++ b/resources/targets.yaml
@@ -74,7 +74,7 @@ items:
           label: konveyor.io/target=openliberty
     - uuid: 809b0710-8bb2-4345-94c0-f8bb274ffc72
       name: Camel
-      description: A comprehensive set of rules for migration to Apache Camel 3 and 4.
+      description: A comprehensive set of rules for migration from Apache Camel 2 to 3 and Camel 3 to 4.
       imagepath: images/multiply.svg
       choice: true
       labels:

--- a/resources/targets.yaml
+++ b/resources/targets.yaml
@@ -58,6 +58,12 @@ items:
       labels:
         - name: Spring Boot
           label: konveyor.io/target=rhr
+    - name: JBoss Web Server 6
+      description: A collection of rules to support migrating from JWS 5 to JWS 6.
+      imagepath: images/eap.svg
+      labels:
+        - name: JWS 6
+          label: konveyor.io/target=jws6
     - uuid: 21941d31-3e8a-46cc-9d3e-b678d4cdeff7
       name: Open Liberty
       description: A comprehensive set of rules for migrating traditional WebSphere applications to Open Liberty.
@@ -67,11 +73,55 @@ items:
           label: konveyor.io/target=openliberty
     - uuid: 809b0710-8bb2-4345-94c0-f8bb274ffc72
       name: Camel
-      description: A comprehensive set of rules for migration from Apache Camel 2 to Apache Camel 3.
+      description: A comprehensive set of rules for migration to Apache Camel 3 and 4.
       imagepath: images/multiply.svg
       labels:
-        - name: Camel
-          label: konveyor.io/target=camel
+        - name: camel:3.0
+          label: konveyor.io/target=camel3
+        - name: camel:3.1
+          label: konveyor.io/target=camel3
+        - name: camel:3.2
+          label: konveyor.io/target=camel3
+        - name: camel:3.3
+          label: konveyor.io/target=camel3
+        - name: camel:3.4
+          label: konveyor.io/target=camel3
+        - name: camel:3.5
+          label: konveyor.io/target=camel3
+        - name: camel:3.6
+          label: konveyor.io/target=camel3
+        - name: camel:3.7
+          label: konveyor.io/target=camel3
+        - name: camel:3.8
+          label: konveyor.io/target=camel3
+        - name: camel:3.9
+          label: konveyor.io/target=camel3
+        - name: camel:3.10
+          label: konveyor.io/target=camel3
+        - name: camel:3.11
+          label: konveyor.io/target=camel3
+        - name: camel:3.12
+          label: konveyor.io/target=camel3
+        - name: camel:3.13
+          label: konveyor.io/target=camel3
+        - name: camel:3.14
+          label: konveyor.io/target=camel3
+        - name: camel:3.15
+          label: konveyor.io/target=camel3
+        - name: camel:3.16
+          label: konveyor.io/target=camel3
+        - name: camel:3.17
+          label: konveyor.io/target=camel3
+        - name: camel:3.18
+          label: konveyor.io/target=camel3
+        - name: camel:3.19
+          label: konveyor.io/target=camel3
+        - name: camel:3.20
+          label: konveyor.io/target=camel3
+        - name: camel:3.21
+          label: konveyor.io/target=camel3
+        - name: camel:4.0
+          label: konveyor.io/target=camel4
     - uuid: e66a777a-ad09-4db8-b7e9-7217a03b4b92
       name: Azure
       description: Upgrade your Java application so it can be deployed on Azure App Service.

--- a/resources/targets.yaml
+++ b/resources/targets.yaml
@@ -35,6 +35,8 @@ items:
           label: konveyor.io/target=openjdk11
         - name: OpenJDK 17
           label: konveyor.io/target=openjdk17
+        - name: OpenJDK 21
+          label: konveyor.io/target=openjdk21
     - uuid: d0d79c05-b6ef-43ad-929a-7ddaecbb83df
       name: Linux
       description: Ensure there are no Microsoft Windows paths hard coded into your applications.

--- a/resources/targets.yaml
+++ b/resources/targets.yaml
@@ -64,7 +64,7 @@ items:
       imagepath: images/eap.svg
       labels:
         - name: JWS 6
-          label: konveyor.io/target=jws6
+          label: konveyor.io/target=jws6+
     - uuid: 21941d31-3e8a-46cc-9d3e-b678d4cdeff7
       name: Open Liberty
       description: A comprehensive set of rules for migrating traditional WebSphere applications to Open Liberty.
@@ -79,51 +79,51 @@ items:
       choice: true
       labels:
         - name: camel:3.0
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.1
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.2
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.3
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.4
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.5
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.6
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.7
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.8
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.9
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.10
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.11
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.12
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.13
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.14
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.15
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.16
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.17
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.18
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.19
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.20
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:3.21
-          label: konveyor.io/target=camel3
+          label: konveyor.io/target=camel3+
         - name: camel:4.0
-          label: konveyor.io/target=camel4
+          label: konveyor.io/target=camel4+
     - uuid: e66a777a-ad09-4db8-b7e9-7217a03b4b92
       name: Azure
       description: Upgrade your Java application so it can be deployed on Azure App Service.

--- a/resources/targets.yaml
+++ b/resources/targets.yaml
@@ -64,7 +64,7 @@ items:
       imagepath: images/eap.svg
       labels:
         - name: JWS 6
-          label: konveyor.io/target=jws6+
+          label: konveyor.io/target=jws6
     - uuid: 21941d31-3e8a-46cc-9d3e-b678d4cdeff7
       name: Open Liberty
       description: A comprehensive set of rules for migrating traditional WebSphere applications to Open Liberty.
@@ -79,51 +79,51 @@ items:
       choice: true
       labels:
         - name: camel:3.0
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.1
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.2
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.3
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.4
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.5
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.6
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.7
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.8
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.9
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.10
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.11
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.12
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.13
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.14
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.15
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.16
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.17
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.18
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.19
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.20
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:3.21
-          label: konveyor.io/target=camel3+
+          label: konveyor.io/target=camel3
         - name: camel:4.0
-          label: konveyor.io/target=camel4+
+          label: konveyor.io/target=camel4
     - uuid: e66a777a-ad09-4db8-b7e9-7217a03b4b92
       name: Azure
       description: Upgrade your Java application so it can be deployed on Azure App Service.

--- a/resources/targets.yaml
+++ b/resources/targets.yaml
@@ -58,7 +58,8 @@ items:
       labels:
         - name: Spring Boot
           label: konveyor.io/target=rhr
-    - name: JBoss Web Server 6
+    - uuid: b035a041-3ee5-417a-86f2-37e0b43ab5c5
+      name: JBoss Web Server 6
       description: A collection of rules to support migrating from JWS 5 to JWS 6.
       imagepath: images/eap.svg
       labels:


### PR DESCRIPTION
Adds:
jws6
openjdk21
versioned camel targets (includes 4.0).