### PR TITLE
Fix unwanted root in the manifest.

### DIFF
--- a/cmd/ruleset/main.go
+++ b/cmd/ruleset/main.go
@@ -75,7 +75,7 @@ func (r *Cmd) Main() (err error) {
 	r.Path = *resources
 	r.Remote.URL = *remote
 	r.Remote.Ref = *ref
-	r.Manifest.Current.Root = *resources
+	r.Manifest.Current.root = *resources
 
 	fmt.Printf("\nResources: %s\n", *resources)
 	fmt.Printf("Remote: %s\n", *remote)
@@ -110,7 +110,7 @@ func (r *Cmd) Reconcile() (err error) {
 	if err != nil {
 		return
 	}
-	r.Manifest.Remote.Root = tmpDir
+	r.Manifest.Remote.root = tmpDir
 	err = r.Manifest.Remote.Build()
 	if err != nil {
 		return
@@ -165,7 +165,7 @@ func (r *Cmd) Apply() (err error) {
 
 func (r *Cmd) ReplaceDir(ruleSet *pkg.RuleSet) (err error) {
 	bash := Bash{Silent: true}
-	remote := path.Join(r.Manifest.Remote.Root, ruleSet.Dir())
+	remote := path.Join(r.Manifest.Remote.root, ruleSet.Dir())
 	current := path.Join(r.Path, ruleSet.Dir())
 	err = bash.Run("rm -rf", current)
 	if err != nil {

--- a/cmd/ruleset/manifest.go
+++ b/cmd/ruleset/manifest.go
@@ -15,7 +15,7 @@ import (
 
 type Manifest struct {
 	pkg.Seed `yaml:",inline"`
-	Root     string
+	root     string
 	path     string
 	ruleSets []*pkg.RuleSet
 	dirMap   map[string]*pkg.RuleSet
@@ -70,7 +70,7 @@ func (r *Manifest) Write() (err error) {
 
 func (r *Manifest) Build() (err error) {
 	r.dirMap = make(map[string]*pkg.RuleSet)
-	p := path.Join(r.Root, RuleSets)
+	p := path.Join(r.root, RuleSets)
 	entries, err := os.ReadDir(p)
 	if err != nil {
 		return
@@ -163,7 +163,7 @@ func (r *Manifest) Delete(ruleSet *pkg.RuleSet) {
 }
 
 func (r *Manifest) SetDetails(ruleSet *pkg.RuleSet) (err error) {
-	p := path.Join(r.Root, ruleSet.Dir(), "ruleset.yaml")
+	p := path.Join(r.root, ruleSet.Dir(), "ruleset.yaml")
 	object := struct {
 		Name        string
 		Description string
@@ -195,7 +195,7 @@ func (r *Manifest) SetDetails(ruleSet *pkg.RuleSet) (err error) {
 }
 
 func (r *Manifest) SetDigest(ruleSet *pkg.RuleSet) (err error) {
-	p := path.Join(r.Root, ruleSet.Dir())
+	p := path.Join(r.root, ruleSet.Dir())
 	b, err := pkg.ChecksumDir(p)
 	if err == nil {
 		ruleSet.Checksum = hex.EncodeToString(b)
@@ -249,7 +249,7 @@ func (r *Manifest) Dirty() (b bool) {
 }
 
 func (r *Manifest) find() (err error) {
-	entries, err := os.ReadDir(r.Root)
+	entries, err := os.ReadDir(r.root)
 	if err != nil {
 		return
 	}
@@ -261,7 +261,7 @@ func (r *Manifest) find() (err error) {
 		if entry.IsDir() {
 			continue
 		}
-		r.path = path.Join(r.Root, entry.Name())
+		r.path = path.Join(r.root, entry.Name())
 		f, err = os.Open(r.path)
 		if err != nil {
 			return


### PR DESCRIPTION
Fix exported Manifest.Root being written to the ruleset.yaml.