### PR TITLE
:seedling: Add global CI, allow custom ruleset args

### DIFF
--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -1,0 +1,49 @@
+name: Global CI
+
+on:
+  push:
+    branches:
+    - main
+    - 'release-*'
+    tags:
+    - 'v*'
+  pull_request:
+    branches:
+    - main
+    - 'release-*'
+
+jobs:
+  build-hub:
+    name: Build tackle2-hub
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        repository: konveyor/tackle2-hub
+        ref: ${{ github.event_name == 'push' && github.ref || github.base_ref }}
+        path: tackle2-hub
+
+    - uses: actions/checkout@v3
+      with:
+        path: tackle2-hub/tackle2-seed
+
+    - name: Build hub and save image
+      working-directory: tackle2-hub
+      run: |
+        IMG=quay.io/konveyor/tackle2-hub:latest make image-podman
+        podman save -o /tmp/tackle2-hub.tar quay.io/konveyor/tackle2-hub:latest
+
+    - name: Upload image as artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: tackle2-hub
+        path: /tmp/tackle2-hub
+        retention-days: 1
+  e2e:
+    needs: build-hub
+    uses: konveyor/ci/.github/workflows/global-ci.yml@main
+    with:
+      component_name: tackle2-hub

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ PREPARE = -o bin/prepare github.com/konveyor/tackle2-seed/cmd/prepare
 RULESET = -o bin/ruleset github.com/konveyor/tackle2-seed/cmd/ruleset
 PKG = ./cmd/... ./pkg/...
 
+RULESET_ARGS ?=
+
 cmd: prepare ruleset
 
 prepare: fmt vet
@@ -21,6 +23,6 @@ run-prepare: prepare
 
 ruleset-patch: cmd
 	bin/prepare
-	bin/ruleset
+	bin/ruleset ${RULESET_ARGS}
 	bin/prepare
 


### PR DESCRIPTION
The custom args  will allow us to override the branch in CI to run tests with a modified ruleset repo on PR, so that we can run checks on the rulesets repo as well before changes are merged.