### PR TITLE
:ghost: Go 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,40 @@
+GOPATH ?= $(HOME)/go
+GOBIN ?= $(GOPATH)/bin
+GOIMPORTS = $(GOBIN)/goimports
+
 PREPARE = -o bin/prepare github.com/konveyor/tackle2-seed/cmd/prepare
 RULESET = -o bin/ruleset github.com/konveyor/tackle2-seed/cmd/ruleset
-PKG = ./cmd/... ./pkg/...
+
+PKG = ./cmd/... \
+      ./pkg/...
+
+PKGDIR = $(subst /...,,$(PKG))
 
 RULESET_ARGS ?=
 
 cmd: prepare ruleset
 
 prepare: fmt vet
-	go build ${PREPARE}
+	go build $(PREPARE)
 
 ruleset: fmt vet
-	go build ${RULESET}
+	go build $(RULESET)
 
-fmt:
-	go fmt ${PKG}
+fmt: $(GOIMPORTS)
+	$(GOIMPORTS) -w $(PKGDIR)
 
 vet:
-	go vet ${PKG}
+	go vet $(PKG)
 
 run-prepare: prepare
 	bin/prepare
 
 ruleset-patch: cmd
 	bin/prepare
-	bin/ruleset ${RULESET_ARGS}
+	bin/ruleset $(RULESET_ARGS)
 	bin/prepare
+
+# Ensure goimports installed.
+$(GOIMPORTS):
+	go install golang.org/x/tools/cmd/goimports@latest
 

--- a/cmd/prepare/main.go
+++ b/cmd/prepare/main.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path"
+	"strings"
+
 	"github.com/google/uuid"
 	"github.com/konveyor/tackle2-seed/pkg"
 	"github.com/pborman/getopt/v2"
 	"gopkg.in/yaml.v3"
-	"os"
-	"path"
-	"strings"
 )
 
 func main() {

--- a/cmd/ruleset/main.go
+++ b/cmd/ruleset/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/konveyor/tackle2-seed/pkg"
-	"github.com/pborman/getopt/v2"
 	"io/ioutil"
 	"os"
 	"path"
+
+	"github.com/konveyor/tackle2-seed/pkg"
+	"github.com/pborman/getopt/v2"
 )
 
 const (

--- a/cmd/ruleset/manifest.go
+++ b/cmd/ruleset/manifest.go
@@ -4,13 +4,14 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/konveyor/tackle2-seed/pkg"
-	"gopkg.in/yaml.v3"
 	"io"
 	"io/ioutil"
 	"os"
 	"path"
 	"strings"
+
+	"github.com/konveyor/tackle2-seed/pkg"
+	"gopkg.in/yaml.v3"
 )
 
 type Manifest struct {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/konveyor/tackle2-seed
 
-go 1.18
+go 1.20
 
 require (
 	github.com/google/uuid v1.3.0

--- a/pkg/ruleset.go
+++ b/pkg/ruleset.go
@@ -1,11 +1,12 @@
 package pkg
 
 import (
-	liberr "github.com/jortel/go-utils/error"
-	"gopkg.in/yaml.v3"
 	"os"
 	"path"
 	"strings"
+
+	liberr "github.com/jortel/go-utils/error"
+	"gopkg.in/yaml.v3"
 )
 
 // RuleSet constants

--- a/pkg/seed.go
+++ b/pkg/seed.go
@@ -4,12 +4,13 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	liberr "github.com/jortel/go-utils/error"
-	"gopkg.in/yaml.v3"
 	"io"
 	"os"
 	"path"
 	"strings"
+
+	liberr "github.com/jortel/go-utils/error"
+	"gopkg.in/yaml.v3"
 )
 
 const (


### PR DESCRIPTION
upgrade Go 1.20.
Replaces gofmt with goimports. Documentation claims it performs the same formatting plus manages/orders imports.
Added missing packages in Makefile.
Updated the go.mod and ran go mod tidy.

closes: #22 

NOT FOR 0.3.