### PR TITLE
:bug: adding discovery label to be used in discovery process

### DIFF
--- a/resources/rulesets.yaml
+++ b/resources/rulesets.yaml
@@ -4,7 +4,7 @@ items:
     - uuid: 10667615-e067-45b4-a925-563a79ea0949
       name: .discovery
       directory: rulesets/00-discovery
-      checksum: 607f7cce00b3e8a495ffa6ccd60000e6d1708a3b52ebd3ed8148770e46585704
+      checksum: 309bc9b01fa0c9435dd155e4441c83d44d843e73e287ac66f5ce028684feca6c
     - uuid: 2eed70c0-305c-4061-bb92-d638ee834e47
       name: azure/springboot
       description: Recommend OpenFeign instead of Feign.
@@ -150,7 +150,7 @@ items:
       name: .technology-usage
       description: This ruleset provides analysis of logging libraries.
       directory: rulesets/technology-usage
-      checksum: 290db0c4bee1a155ca2663f7f144b5be0532a852793fa2332c816c4abde66e18
+      checksum: 048bc1bf70a8382eb2c8d2e68421ab1ec48ca3db0f342242654a08c1f221e8e4
     - uuid: 2a3357e3-c79f-4875-a869-b38cb28ac498
       name: camel3
       description: Rules for changes between Camel 3.0 and Camel 4.0
@@ -190,3 +190,11 @@ items:
         - 10667615-e067-45b4-a925-563a79ea0949
         - 1b2a0eef-511c-4c07-a36a-d301b15d8207
       checksum: f784dd8cb1f99abf28270f0220832a0026b224b91f1d1c27f1227afd49d36266
+    - uuid: eed927d0-fc63-4b64-a75c-ab0bc599c8c6
+      name: dotnet8/dotnetframework45
+      description: This ruleset provides analysis with respect to API changes between .NET Framework 4.5 and .NET 8.
+      directory: rulesets/dotnet8
+      dependencies:
+        - 10667615-e067-45b4-a925-563a79ea0949
+        - 1b2a0eef-511c-4c07-a36a-d301b15d8207
+      checksum: 8209bb37c8709ca1859aa78aab861cd868645bdfb29d2f96e034621a9078c00b

--- a/resources/rulesets/00-discovery/0.yaml
+++ b/resources/rulesets/00-discovery/0.yaml
@@ -76,6 +76,7 @@
       pattern: "pom.xml"
   tag: ["Maven XML"]
 - ruleID: windup-discover-ejb-configuration
+  description: "EJB XML Configuration"
   labels:
   - konveyor.io/include=always
   - konveyor.io/target=discovery
@@ -84,6 +85,7 @@
     builtin.xml:
       xpath: "/(jboss:ejb-jar or ejb-jar)"
 - ruleID: windup-discover-spring-configuration
+  description: "Spring XML Configuration"
   tag: ["Spring XML"]
   labels:
   - konveyor.io/include=always
@@ -92,6 +94,7 @@
     builtin.xml:
       xpath: "/beans"
 - ruleID: windup-discover-jpa-configuration
+  description: "JPA XML Configuration"
   tag: ["JPA XML"]
   labels:
   - konveyor.io/include=always
@@ -105,6 +108,7 @@
       - builtin.xml:
           xpath: '/persistence[boolean(namespace-uri(/persistence)="https://jakarta.ee/xml/ns/persistence")]'
 - ruleID: windup-discover-web-configuration
+  description: "Web XML Configuration"
   labels:
   - konveyor.io/include=always
   - konveyor.io/target=discovery

--- a/resources/rulesets/dotnet8/example.yaml
+++ b/resources/rulesets/dotnet8/example.yaml
@@ -1,0 +1,14 @@
+- category: mandatory
+  customVariables: []
+  description: MVC Method names have changed from .NET Framework
+  effort: 1
+  labels:
+  - konveyor.io/source=dotnetframework
+  message: |-
+    HttpNotFound was replaced with NotFound in .NET Core
+  ruleID: removed-dotnet-framework-00000
+  when:
+    or:
+    - dotnet.referenced:
+        pattern: "HttpNotFound"
+        namespace: "System.Web.Mvc"

--- a/resources/rulesets/dotnet8/ruleset.yaml
+++ b/resources/rulesets/dotnet8/ruleset.yaml
@@ -1,0 +1,3 @@
+name: dotnet8/dotnetframework45
+description: This ruleset provides analysis with respect to API changes between
+  .NET Framework 4.5 and .NET 8.

--- a/resources/rulesets/technology-usage/ruleset.yaml
+++ b/resources/rulesets/technology-usage/ruleset.yaml
@@ -1,2 +1,4 @@
 name: technology-usage
 description: This ruleset provides analysis of logging libraries.
+labels:
+- discovery


### PR DESCRIPTION
I believe that is is need, for the technology rules to be selected by default. 

The default label is here:
https://github.com/konveyor/tackle2-hub/blob/main/settings/hub.go#L279-L280

which whill IIUC find the task here:
https://github.com/konveyor/operator/blob/main/roles/tackle/templates/customresource-addon-tech-discovery.yml.j2#L106-L124

which is using     

```
rules:
      labels:
        included: ["discovery"]
```

IIUC this information is seeded in the database for when retrieving rules, right now I have a feeling that only the ```00_discovery``` rules are run in discovery tasks