### PR TITLE
:seedling: Update global-ci.yaml upload-artifact

### DIFF
--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -37,7 +37,7 @@ jobs:
         podman save -o /tmp/tackle2-hub.tar quay.io/konveyor/tackle2-hub:latest
 
     - name: Upload image as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tackle2-hub
         path: /tmp/tackle2-hub.tar


### PR DESCRIPTION
Update of github workflows addressing deprecations (ubuntu-20.04 runner and/or (upload|download)-artifact@v3), related to https://github.com/konveyor/ci/issues/83