### PR TITLE
:ghost: Nested directories in rulesets ignored.

### DIFF
--- a/cmd/ruleset/main.go
+++ b/cmd/ruleset/main.go
@@ -197,6 +197,9 @@ func (r *Cmd) CopyTree(bash Bash, depth int, source, dest string) (err error) {
 				depth-1,
 				path.Join(source, ent.Name()),
 				path.Join(dest, ent.Name()))
+			if err != nil {
+				return
+			}
 			continue
 		}
 		err = bash.Run(


### PR DESCRIPTION
Using `cp -r` picks up embedded /test*/ directories.  Omitting the /test/ directories by name is difficult because they are not named consistently and there is some concern about omitting a legitimate ruleset containing the "test" in the name.
 `cp` command does not support depth limit. 
`rsync` added --max-depth in version 3.2.3.  Even still, it was a little messy. 
Updated to use CopyTree() which ignores them. 