### PR TITLE
:sparkles: Seed generators

### DIFF
--- a/cmd/prepare/main.go
+++ b/cmd/prepare/main.go
@@ -142,6 +142,22 @@ func main() {
 					panic(err)
 				}
 			}
+		case pkg.KindGenerator:
+			for i := range seed.Items {
+				item := &seed.Items[i]
+				g := pkg.Generator{}
+				err = item.Decode(&g)
+				if err != nil {
+					panic(err)
+				}
+				if g.UUID == "" {
+					g.UUID = uuid.NewString()
+				}
+				err = item.Encode(g)
+				if err != nil {
+					panic(err)
+				}
+			}
 		default:
 		}
 		seedsByFile[seed.Filename()] = append(seedsByFile[seed.Filename()], seed)

--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -1,1 +1,3 @@
 package pkg
+
+type Map map[string]any

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -1,0 +1,19 @@
+package pkg
+
+type Generator struct {
+	UUID        string
+	Kind        string
+	Name        string
+	Description string
+	Repository  Repository
+	Params      Map
+	Values      Map
+}
+
+type Repository struct {
+	Kind   string
+	URL    string
+	Branch string
+	Tag    string
+	Path   string
+}

--- a/pkg/seed.go
+++ b/pkg/seed.go
@@ -24,6 +24,7 @@ const (
 	KindTagCategory   = "tagcategory"
 	KindTarget        = "target"
 	KindQuestionnaire = "questionnaire"
+	KindGenerator     = "generator"
 )
 
 // Seed document structure.

--- a/pkg/seed.go
+++ b/pkg/seed.go
@@ -89,6 +89,13 @@ func (r *Seed) DecodeItems() (decoded []interface{}, err error) {
 				return
 			}
 			decoded = append(decoded, item)
+		case KindGenerator:
+			item := Generator{}
+			err = encoded.Decode(&item)
+			if err != nil {
+				return
+			}
+			decoded = append(decoded, item)
 		default:
 			err = liberr.New("unknown kind")
 			return

--- a/resources/generators.yaml
+++ b/resources/generators.yaml
@@ -10,6 +10,6 @@ items:
         url: https://github.com/konveyor/cf-k8s-helm-chart.git
         branch: ""
         tag: ""
-        path: resources/helm/openshift
+        path: ""
       params: {}
       values: {}

--- a/resources/generators.yaml
+++ b/resources/generators.yaml
@@ -3,8 +3,8 @@ version: 1
 items:
     - uuid: 8b25ed8e-f55d-404f-a5d2-819e698b2549
       kind: helm
-      name: Openshift
-      description: Cloud Foundry => Openshift.
+      name: CloudFoundry-Openshift
+      description: Generate openshift assets using a Cloud Foundry application manifest.
       repository:
         kind: git
         url: https://github.com/konveyor/cf-k8s-helm-chart.git

--- a/resources/generators.yaml
+++ b/resources/generators.yaml
@@ -1,0 +1,15 @@
+kind: Generator
+version: 1
+items:
+    - uuid: 8b25ed8e-f55d-404f-a5d2-819e698b2549
+      kind: helm
+      name: Openshift
+      description: Openshift Generator.
+      repository:
+        kind: git
+        url: https://github.com/konveyor/tackle2-seed.git
+        branch: ""
+        tag: ""
+        path: resources/helm/openshift
+      params: {}
+      values: {}

--- a/resources/generators.yaml
+++ b/resources/generators.yaml
@@ -4,7 +4,7 @@ items:
     - uuid: 8b25ed8e-f55d-404f-a5d2-819e698b2549
       kind: helm
       name: Openshift
-      description: Openshift Generator.
+      description: Cloud Foundry => Openshift.
       repository:
         kind: git
         url: https://github.com/konveyor/cf-k8s-helm-chart.git

--- a/resources/generators.yaml
+++ b/resources/generators.yaml
@@ -7,7 +7,7 @@ items:
       description: Openshift Generator.
       repository:
         kind: git
-        url: https://github.com/konveyor/tackle2-seed.git
+        url: https://github.com/konveyor/cf-k8s-helm-chart.git
         branch: ""
         tag: ""
         path: resources/helm/openshift


### PR DESCRIPTION
closes #78 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for Generator resources so generators can be defined and managed like other seed types.
  - Generators now receive UUIDs automatically when missing during preparation.
  - Included a default Helm-based generator manifest for Cloud Foundry → OpenShift to help users get started.

- Chores
  - Introduced foundational types and declarations to represent generators and their repositories for configuration and interoperability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->