### PR TITLE
:ghost: generator repository v0.1.0.

### DIFF
--- a/resources/generators.yaml
+++ b/resources/generators.yaml
@@ -9,7 +9,7 @@ items:
         kind: git
         url: https://github.com/konveyor/cf-k8s-helm-chart.git
         branch: ""
-        tag: ""
+        tag: "v0.1.0"
         path: "java-backend"
       params: {}
       values: {}

--- a/resources/generators.yaml
+++ b/resources/generators.yaml
@@ -8,8 +8,8 @@ items:
       repository:
         kind: git
         url: https://github.com/konveyor/cf-k8s-helm-chart.git
-        branch: ""
-        tag: "v0.1.0"
+        branch: "v0.1.0"
+        tag: ""
         path: "java-backend"
       params: {}
       values: {}


### PR DESCRIPTION
For git, there isn't any difference between a branch and a tag.  Using branch because the UI does not support tags.

close #84 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Pinned the CloudFoundry-OpenShift generator’s Java backend source to branch v0.1.0.
  - Produces more consistent, reproducible project scaffolding across environments.
  - Improves stability during setup and CI runs with no changes to user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->