### PR TITLE
:sparkles: Add Quarkus migration rules for JNDI, transactions, and JPA

### DIFF
--- a/resources/generators.yaml
+++ b/resources/generators.yaml
@@ -8,8 +8,8 @@ items:
       repository:
         kind: git
         url: https://github.com/konveyor/cf-k8s-helm-chart.git
-        branch: "v0.1.0"
+        branch: v0.1.0
         tag: ""
-        path: "java-backend"
+        path: java-backend
       params: {}
       values: {}

--- a/resources/rulesets.yaml
+++ b/resources/rulesets.yaml
@@ -12,7 +12,7 @@ items:
       dependencies:
         - 10667615-e067-45b4-a925-563a79ea0949
         - 1b2a0eef-511c-4c07-a36a-d301b15d8207
-      checksum: 12726aeb3a4e29d1577a63bf551b2f55342ce661e87af26fd70200386488e2af
+      checksum: a13a01315da176a0966ebfa3f4f8f233c61104d9dcc4e74b870703e285e1bf40
     - uuid: e92057bc-5b66-4f7d-976f-f76aa3ad50e6
       name: camel3/camel2
       description: Rules for changes in XML file (e.g. pom.xml) to run on Apache Camel 3
@@ -20,7 +20,7 @@ items:
       dependencies:
         - 10667615-e067-45b4-a925-563a79ea0949
         - 1b2a0eef-511c-4c07-a36a-d301b15d8207
-      checksum: 2d4ee3bf8f7500a38ed2b49a93939f62caea11d2d81dc646453752c4298e1163
+      checksum: b054e9c9ebd49660123d208aa855b3d99ced2f2322ef0a4794b75c0b06db0f70
     - uuid: eb900f9e-6ff3-413d-9023-167765ce1311
       name: droolsjbpm
       description: This ruleset provides help for migrating to a unified KIE (Knowledge Is Everything) API in the upgrade from version 5 to 6.
@@ -43,7 +43,7 @@ items:
       dependencies:
         - 10667615-e067-45b4-a925-563a79ea0949
         - 1b2a0eef-511c-4c07-a36a-d301b15d8207
-      checksum: 0e52147b51530f1c728d1587b50526c57c9ce9ee79bd6b0270da187299f4008e
+      checksum: b9978a624c008c445471883e7f8ac5967de04b4a99008586446ef91aa4f511a9
     - uuid: 3c471738-dfcf-46e8-b803-df07c304acc7
       name: eap8/eap7
       description: This ruleset provides analysis of Java EE applications that need to change certain CDI-related method calls.
@@ -51,7 +51,7 @@ items:
       dependencies:
         - 10667615-e067-45b4-a925-563a79ea0949
         - 1b2a0eef-511c-4c07-a36a-d301b15d8207
-      checksum: 95d12dfdda1aeba15f1e1d199206181c999c5bdac52765147754a4a8f2f9763b
+      checksum: 82c851cea5201d05b8982dfc8081b438727a326cc6c2f93a4d4029668ee89a28
     - uuid: 288037b2-279f-4d11-9ea9-f91ff274447f
       name: eapxp/thorntail
       description: This ruleset provides analysis of Maven built applications that use Thorntail Maven Plugin, which should be replaced by JBoss EAP XP Bootable JAR Maven Plugin, when migrating to JBoss EAP XP.
@@ -137,7 +137,7 @@ items:
       dependencies:
         - 10667615-e067-45b4-a925-563a79ea0949
         - 1b2a0eef-511c-4c07-a36a-d301b15d8207
-      checksum: 07772613f792e82f2f1e4888996798c4e7d2cf66dac0f2c4d7f0f9cfd7a9e7c9
+      checksum: 58ae73cebe6f973880c893b6742d8b58d8ef2333505debf509d7b741c0901d69
     - uuid: 9179982c-6007-4e40-b67c-9a7272e44e87
       name: rhr/springboot
       description: Verify the version of the Spring Boot framework is compatible with those supported by Red Hat Runtimes
@@ -150,7 +150,7 @@ items:
       name: .technology-usage
       description: This ruleset provides analysis of logging libraries.
       directory: rulesets/technology-usage
-      checksum: 8ea1810396f446704212f5a3af3b973505cb513ecb6cd526683bee8922729f5a
+      checksum: 177ae89b6cd719bb757956147806aa6d685fac072cb828e49f2a1d89da28c9f5
     - uuid: 2a3357e3-c79f-4875-a869-b38cb28ac498
       name: camel3
       description: Rules for changes between Camel 3.0 and Camel 4.0
@@ -174,7 +174,7 @@ items:
       dependencies:
         - 10667615-e067-45b4-a925-563a79ea0949
         - 1b2a0eef-511c-4c07-a36a-d301b15d8207
-      checksum: ca826c23abf9a39c403e2ad01656c3f896a6195cb5004fc9add7ebecadc9779e
+      checksum: 8b39719aa8383c18adb82232ffdfdbb3dacde744cf1f79a7c90eb7f1ea6fd405
     - uuid: e981e01a-5722-4df0-bf01-9e0694e7bb05
       name: cloud-readiness
       description: This ruleset detects logging configurations that may be problematic when migrating an application to a cloud environment.

--- a/resources/rulesets/azure/01-azure-aws-config.windup.yaml
+++ b/resources/rulesets/azure/01-azure-aws-config.windup.yaml
@@ -71,10 +71,9 @@
      Consider using Azure Blob Storage instead.
   ruleID: azure-aws-config-s3-03000
   when:
-    or:
-    - builtin.filecontent:
-        filePattern: ""
-        pattern: aws.s3
+    builtin.filecontent:
+      filePattern: ""
+      pattern: aws.s3
 - category: potential
   customVariables: []
   description: Amazon Simple Queue Service configuration
@@ -94,10 +93,9 @@
      Consider using Azure Service Bus instead.
   ruleID: azure-aws-config-sqs-04000
   when:
-    or:
-    - builtin.filecontent:
-        filePattern: ""
-        pattern: aws.sqs
+    builtin.filecontent:
+      filePattern: ""
+      pattern: aws.sqs
 - category: potential
   customVariables: []
   description: AWS Secrets Manager configuration

--- a/resources/rulesets/camel3/34-java-generic-information.windup.yaml
+++ b/resources/rulesets/camel3/34-java-generic-information.windup.yaml
@@ -540,10 +540,9 @@
     out of `org.apache.camel:camel-core` and into `org.apache.camel:camel-support`.
   ruleID: java-generic-information-00029
   when:
-    or:
-    - java.referenced:
-        location: IMPORT
-        pattern: org.apache.camel.processor.idempotent.(FileIdempotentRepository|MemoryIdempotentRepository)
+    java.referenced:
+      location: IMPORT
+      pattern: org.apache.camel.processor.idempotent.(FileIdempotentRepository|MemoryIdempotentRepository)
 - category: mandatory
   customVariables: []
   description: Annotation `org.apache.camel.FallbackConverter` has been removed

--- a/resources/rulesets/eap7/107-eap6-xml.windup.yaml
+++ b/resources/rulesets/eap7/107-eap6-xml.windup.yaml
@@ -45,10 +45,9 @@
   - configuration
   - JBoss deployment structure dependencies (jboss-deployment-structure.xml)
   when:
-    or:
-    - builtin.xml:
-        filepaths:
-        - jboss-deployment-structure.xml
-        namespaces: {}
-        xpath: /*[local-name()='jboss-deployment-structure']/*[local-name()='deployment'
-          or local-name()='sub-deployment' or local-name()='module']/*[local-name()='dependencies']
+    builtin.xml:
+      filepaths:
+      - jboss-deployment-structure.xml
+      namespaces: {}
+      xpath: /*[local-name()='jboss-deployment-structure']/*[local-name()='deployment'
+        or local-name()='sub-deployment' or local-name()='module']/*[local-name()='dependencies']

--- a/resources/rulesets/eap8/147-eap8-xml-binding.windup.yaml
+++ b/resources/rulesets/eap8/147-eap8-xml-binding.windup.yaml
@@ -176,10 +176,9 @@
      to conform to the more fully specified generic type signatures in Jakarta Xml Binding 4.0.
   ruleID: eap8-xml-binding-00007
   when:
-    or:
-    - java.referenced:
-        location: METHOD_CALL
-        pattern: javax.xml.bind.Marshaller.setAdapter
+    java.referenced:
+      location: METHOD_CALL
+      pattern: javax.xml.bind.Marshaller.setAdapter
 - category: mandatory
   customVariables: []
   description: Outdated JAXB dependency
@@ -227,7 +226,6 @@
      to conform to the more fully specified generic type signatures in Jakarta Xml Binding 4.0.
   ruleID: eap8-xml-binding-00009
   when:
-    or:
-    - java.referenced:
-        location: METHOD_CALL
-        pattern: javax.xml.bind.Marshaller.getAdapter
+    java.referenced:
+      location: METHOD_CALL
+      pattern: javax.xml.bind.Marshaller.getAdapter

--- a/resources/rulesets/eap8/152-hibernate-search-6.1.windup.yaml
+++ b/resources/rulesets/eap8/152-hibernate-search-6.1.windup.yaml
@@ -49,9 +49,8 @@
     been moved to `org.hibernate.search.engine.cfg.ConfigurationPropertySource`.'
   ruleID: hibernate-search-6.1-00020
   when:
-    or:
-    - java.referenced:
-        pattern: org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource
+    java.referenced:
+      pattern: org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource
 - category: mandatory
   customVariables: []
   description: org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchHttpClientConfigurer
@@ -75,9 +74,8 @@
     and is now an API.'
   ruleID: hibernate-search-6.1-00030
   when:
-    or:
-    - java.referenced:
-        pattern: org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchHttpClientConfigurer
+    java.referenced:
+      pattern: org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchHttpClientConfigurer
 - category: mandatory
   customVariables: []
   description: org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchHttpClientConfigurationContext
@@ -101,9 +99,8 @@
     and is now an API.'
   ruleID: hibernate-search-6.1-00040
   when:
-    or:
-    - java.referenced:
-        pattern: org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchHttpClientConfigurationContext
+    java.referenced:
+      pattern: org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchHttpClientConfigurationContext
 - category: mandatory
   customVariables: []
   description: org.hibernate.search.engine.common.timing.spi.Deadline has moved
@@ -125,9 +122,8 @@
     and is now API.'
   ruleID: hibernate-search-6.1-00050
   when:
-    or:
-    - java.referenced:
-        pattern: org.hibernate.search.engine.common.timing.spi.Deadline
+    java.referenced:
+      pattern: org.hibernate.search.engine.common.timing.spi.Deadline
 - category: mandatory
   customVariables: []
   description: org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlanExecutionReport
@@ -150,9 +146,8 @@
     is now `org.hibernate.search.engine.backend.work.execution.spi.MultiEntityOperationExecutionReport`.'
   ruleID: hibernate-search-6.1-00060
   when:
-    or:
-    - java.referenced:
-        pattern: org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlanExecutionReport
+    java.referenced:
+      pattern: org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlanExecutionReport
 - category: mandatory
   customVariables: []
   description: URLEncodedString#fromJsonString was removed
@@ -173,10 +168,9 @@
   message: '`URLEncodedString#fromJsonString` must be removed.'
   ruleID: hibernate-search-6.1-00070
   when:
-    or:
-    - java.referenced:
-        location: METHOD_CALL
-        pattern: org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString.fromJsonString
+    java.referenced:
+      location: METHOD_CALL
+      pattern: org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString.fromJsonString
 - category: mandatory
   customVariables: []
   description: FieldPaths#absolutize(String, String, String) has been removed
@@ -197,10 +191,9 @@
   message: '`FieldPaths#absolutize(String, String, String)` must be removed.'
   ruleID: hibernate-search-6.1-00080
   when:
-    or:
-    - java.referenced:
-        location: METHOD_CALL
-        pattern: org.hibernate.search.engine.backend.common.spi.FieldPaths.absolutize(java.lang.String,java.lang.String,java.lang.String)
+    java.referenced:
+      location: METHOD_CALL
+      pattern: org.hibernate.search.engine.backend.common.spi.FieldPaths.absolutize(java.lang.String,java.lang.String,java.lang.String)
 - category: mandatory
   customVariables: []
   description: IndexManagerImplementor#createIndexingPlan has changed
@@ -222,10 +215,9 @@
     parameter.'
   ruleID: hibernate-search-6.1-00090
   when:
-    or:
-    - java.referenced:
-        location: METHOD_CALL
-        pattern: org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor.createIndexingPlan
+    java.referenced:
+      location: METHOD_CALL
+      pattern: org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor.createIndexingPlan
 - category: mandatory
   customVariables: []
   description: IndexIndexingPlan#executeAndReport has changed
@@ -247,10 +239,9 @@
     parameter.'
   ruleID: hibernate-search-6.1-00100
   when:
-    or:
-    - java.referenced:
-        location: METHOD_CALL
-        pattern: org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan.executeAndReport
+    java.referenced:
+      location: METHOD_CALL
+      pattern: org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan.executeAndReport
 - category: mandatory
   customVariables: []
   description: IndexSchemaObjectNodeBuilder has changed
@@ -272,9 +263,8 @@
     is now `org.hibernate.search.engine.backend.document.model.dsl.spi.IndexCompositeNodeBuilder`'
   ruleID: hibernate-search-6.1-00120
   when:
-    or:
-    - java.referenced:
-        pattern: org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaObjectNodeBuilder
+    java.referenced:
+      pattern: org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaObjectNodeBuilder
 - category: mandatory
   customVariables: []
   description: IndexSchemaObjectNodeBuilder has changed
@@ -296,9 +286,8 @@
     is now `org.hibernate.search.engine.backend.document.model.dsl.spi.IndexObjectFieldBuilder`'
   ruleID: hibernate-search-6.1-00130
   when:
-    or:
-    - java.referenced:
-        pattern: org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaObjectFieldNodeBuilder
+    java.referenced:
+      pattern: org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaObjectFieldNodeBuilder
 - category: mandatory
   customVariables: []
   description: IndexSchemaObjectNodeBuilder has changed
@@ -320,9 +309,8 @@
     is now `org.hibernate.search.engine.backend.document.model.dsl.spi.IndexRootBuilder`'
   ruleID: hibernate-search-6.1-00140
   when:
-    or:
-    - java.referenced:
-        pattern: org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaObjectFieldNodeBuilder
+    java.referenced:
+      pattern: org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaObjectFieldNodeBuilder
 - category: optional
   customVariables: []
   description: FromDocumentFieldValueConverter has been deprecated

--- a/resources/rulesets/eap8/166-javax-to-jakarta-servlet.windup.yaml
+++ b/resources/rulesets/eap8/166-javax-to-jakarta-servlet.windup.yaml
@@ -101,10 +101,9 @@
   message: Method getServlet in javax.servlet.ServletContext has been removed.
   ruleID: javax-to-jakarta-servlet-00040
   when:
-    or:
-    - java.referenced:
-        location: METHOD_CALL
-        pattern: javax.servlet.ServletContext.getServlet
+    java.referenced:
+      location: METHOD_CALL
+      pattern: javax.servlet.ServletContext.getServlet
 - category: mandatory
   customVariables: []
   description: Method getServlets in javax.servlet.ServletContext has been removed
@@ -124,10 +123,9 @@
   message: Method getServlets in javax.servlet.ServletContext has been removed.
   ruleID: javax-to-jakarta-servlet-00041
   when:
-    or:
-    - java.referenced:
-        location: METHOD_CALL
-        pattern: javax.servlet.ServletContext.getServlets
+    java.referenced:
+      location: METHOD_CALL
+      pattern: javax.servlet.ServletContext.getServlets
 - category: mandatory
   customVariables: []
   description: Method getServletNames in javax.servlet.ServletContext has been removed
@@ -147,10 +145,9 @@
   message: Method getServletNames in javax.servlet.ServletContext has been removed.
   ruleID: javax-to-jakarta-servlet-00042
   when:
-    or:
-    - java.referenced:
-        location: METHOD_CALL
-        pattern: javax.servlet.ServletContext.getServletNames
+    java.referenced:
+      location: METHOD_CALL
+      pattern: javax.servlet.ServletContext.getServletNames
 - category: mandatory
   customVariables: []
   description: Method log(Exception, String) in javax.servlet.ServletContext has been
@@ -172,10 +169,9 @@
     removed. Use log(String, Throwable) instead.
   ruleID: javax-to-jakarta-servlet-00043
   when:
-    or:
-    - java.referenced:
-        pattern: ServletContext.log(Exception,String)
-        location: METHOD_CALL
+    java.referenced:
+      pattern: ServletContext.log(Exception,String)
+      location: METHOD_CALL
 - category: mandatory
   customVariables: []
   description: Method in javax.servlet.ServletRequest has been removed

--- a/resources/rulesets/eap8/170-log4j-removed.windup.yaml
+++ b/resources/rulesets/eap8/170-log4j-removed.windup.yaml
@@ -50,10 +50,9 @@
   ruleID: log4j-removed-00002
   when:
     or:
-    - and:
-      - java.referenced:
-          location: IMPORT
-          pattern: org.apache.log4j.Logger
+    - java.referenced:
+        location: IMPORT
+        pattern: org.apache.log4j.Logger
     - not: true
       or:
       - java.dependency:

--- a/resources/rulesets/openjdk21/201-deprecation-openjdk21.windup.yaml
+++ b/resources/rulesets/openjdk21/201-deprecation-openjdk21.windup.yaml
@@ -12,7 +12,6 @@
     JDK 21 for removal in a future release.
   ruleID: deprecation-00030
   when:
-    or:
-    - java.referenced:
-        location: METHOD_CALL
-        pattern: javax.swing.plaf.synth.SynthLookAndFeel.load(java.net.URL)
+    java.referenced:
+      location: METHOD_CALL
+      pattern: javax.swing.plaf.synth.SynthLookAndFeel.load(java.net.URL)

--- a/resources/rulesets/quarkus/201-persistence-to-quarkus.windup.yaml
+++ b/resources/rulesets/quarkus/201-persistence-to-quarkus.windup.yaml
@@ -43,6 +43,42 @@
         pattern: persistence\.xml
     - builtin.file:
         pattern: .*-ds\.xml
+- category: optional
+  customVariables: []
+  description: Replace @PersistenceContext with @Inject
+  effort: 1
+  labels:
+  - konveyor.io/source=java-ee
+  - konveyor.io/source=jakarta-ee
+  - konveyor.io/target=quarkus
+  links:
+  - title: Using Hibernate ORM and Jakarta persistence
+    url: https://quarkus.io/guides/hibernate-orm
+  message: |-
+    Replace `@PersistenceContext` with `@Inject` for EntityManager injection in Quarkus.
+
+    In Java EE/Jakarta EE, `@PersistenceContext` was used to inject EntityManager:
+    ```java
+    @PersistenceContext
+    EntityManager entityManager;
+    ```
+
+    In Quarkus, use `@Inject` instead:
+    ```java
+    @Inject
+    EntityManager entityManager;
+    ```
+
+    Ensure your datasource is properly configured in `application.properties`.
+  ruleID: persistence-to-quarkus-00010
+  when:
+    or:
+    - java.referenced:
+        location: ANNOTATION
+        pattern: javax.persistence.PersistenceContext
+    - java.referenced:
+        location: ANNOTATION
+        pattern: jakarta.persistence.PersistenceContext
 - category: potential
   customVariables: []
   description: '@Produces cannot annotate an EntityManager'

--- a/resources/rulesets/quarkus/238-jndi-to-quarkus.yaml
+++ b/resources/rulesets/quarkus/238-jndi-to-quarkus.yaml
@@ -1,0 +1,68 @@
+- category: mandatory
+  customVariables: []
+  description: JNDI InitialContext is not supported in Quarkus
+  effort: 5
+  labels:
+  - konveyor.io/source=java-ee
+  - konveyor.io/source=jakarta-ee
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus CDI Reference
+    url: https://quarkus.io/guides/cdi-reference
+  message: |-
+    JNDI lookups via `InitialContext` are not supported in Quarkus.
+    Use CDI `@Inject` instead to inject dependencies directly.
+
+    Replace JNDI lookups with CDI injection:
+    ```java
+    // Before (Java EE/Jakarta EE):
+    InitialContext ctx = new InitialContext();
+    MyService service = (MyService) ctx.lookup("java:app/MyService");
+
+    // After (Quarkus with CDI):
+    @Inject
+    MyService service;
+    ```
+  ruleID: jndi-to-quarkus-00001
+  when:
+    java.referenced:
+      location: CONSTRUCTOR_CALL
+      pattern: javax.naming.InitialContext
+- category: mandatory
+  customVariables: []
+  description: JNDI lookup() method is not supported in Quarkus
+  effort: 5
+  labels:
+  - konveyor.io/source=java-ee
+  - konveyor.io/source=jakarta-ee
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus CDI Reference
+    url: https://quarkus.io/guides/cdi-reference
+  message: |-
+    JNDI lookups using the `lookup()` method are not supported in Quarkus.
+    Use CDI `@Inject` instead to inject dependencies directly.
+
+    Replace JNDI lookups with CDI injection:
+    ```java
+    // Before (Java EE/Jakarta EE):
+    Context ctx = new InitialContext();
+    DataSource ds = (DataSource) ctx.lookup("java:jboss/datasources/MyDS");
+
+    // After (Quarkus with CDI):
+    @Inject
+    AgroalDataSource dataSource;
+    ```
+
+    For datasources specifically, configure them in `application.properties`:
+    ```
+    quarkus.datasource.db-kind=postgresql
+    quarkus.datasource.username=username
+    quarkus.datasource.password=password
+    quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/mydb
+    ```
+  ruleID: jndi-to-quarkus-00002
+  when:
+    java.referenced:
+      location: METHOD_CALL
+      pattern: javax.naming.Context.lookup*

--- a/resources/rulesets/quarkus/239-transaction-to-quarkus.yaml
+++ b/resources/rulesets/quarkus/239-transaction-to-quarkus.yaml
@@ -1,0 +1,111 @@
+- category: mandatory
+  customVariables: []
+  description: EntityManager persistence operations require @Transactional in Quarkus
+  effort: 3
+  labels:
+  - konveyor.io/source=java-ee
+  - konveyor.io/source=jakarta-ee
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus Hibernate ORM Guide
+    url: https://quarkus.io/guides/hibernate-orm
+  - title: Quarkus Transaction Guide
+    url: https://quarkus.io/guides/transaction
+  message: |-
+    Methods that modify data using EntityManager operations (persist, merge, remove) must be annotated with `@Transactional` in Quarkus.
+
+    Ensure that methods containing `entityManager.persist()` are properly annotated:
+    ```java
+    import jakarta.transaction.Transactional;
+
+    @Transactional
+    public void saveEntity(MyEntity entity) {
+        entityManager.persist(entity);
+    }
+    ```
+
+    Note: In Java EE/Jakarta EE application servers, transactions are often managed automatically by the container (CMT - Container Managed Transactions).
+    In Quarkus, you must explicitly mark transactional boundaries using `@Transactional` annotation.
+  ruleID: transaction-to-quarkus-00001
+  when:
+    or:
+    - java.referenced:
+        location: METHOD_CALL
+        pattern: javax.persistence.EntityManager.persist*
+    - java.referenced:
+        location: METHOD_CALL
+        pattern: jakarta.persistence.EntityManager.persist*
+- category: mandatory
+  customVariables: []
+  description: EntityManager merge operations require @Transactional in Quarkus
+  effort: 3
+  labels:
+  - konveyor.io/source=java-ee
+  - konveyor.io/source=jakarta-ee
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus Hibernate ORM Guide
+    url: https://quarkus.io/guides/hibernate-orm
+  - title: Quarkus Transaction Guide
+    url: https://quarkus.io/guides/transaction
+  message: |-
+    Methods that modify data using EntityManager operations (persist, merge, remove) must be annotated with `@Transactional` in Quarkus.
+
+    Ensure that methods containing `entityManager.merge()` are properly annotated:
+    ```java
+    import jakarta.transaction.Transactional;
+
+    @Transactional
+    public void updateEntity(MyEntity entity) {
+        entityManager.merge(entity);
+    }
+    ```
+
+    Note: In Java EE/Jakarta EE application servers, transactions are often managed automatically by the container (CMT - Container Managed Transactions).
+    In Quarkus, you must explicitly mark transactional boundaries using `@Transactional` annotation.
+  ruleID: transaction-to-quarkus-00002
+  when:
+    or:
+    - java.referenced:
+        location: METHOD_CALL
+        pattern: javax.persistence.EntityManager.merge*
+    - java.referenced:
+        location: METHOD_CALL
+        pattern: jakarta.persistence.EntityManager.merge*
+- category: mandatory
+  customVariables: []
+  description: EntityManager remove operations require @Transactional in Quarkus
+  effort: 3
+  labels:
+  - konveyor.io/source=java-ee
+  - konveyor.io/source=jakarta-ee
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus Hibernate ORM Guide
+    url: https://quarkus.io/guides/hibernate-orm
+  - title: Quarkus Transaction Guide
+    url: https://quarkus.io/guides/transaction
+  message: |-
+    Methods that modify data using EntityManager operations (persist, merge, remove) must be annotated with `@Transactional` in Quarkus.
+
+    Ensure that methods containing `entityManager.remove()` are properly annotated:
+    ```java
+    import jakarta.transaction.Transactional;
+
+    @Transactional
+    public void deleteEntity(MyEntity entity) {
+        entityManager.remove(entity);
+    }
+    ```
+
+    Note: In Java EE/Jakarta EE application servers, transactions are often managed automatically by the container (CMT - Container Managed Transactions).
+    In Quarkus, you must explicitly mark transactional boundaries using `@Transactional` annotation.
+  ruleID: transaction-to-quarkus-00003
+  when:
+    or:
+    - java.referenced:
+        location: METHOD_CALL
+        pattern: javax.persistence.EntityManager.remove*
+    - java.referenced:
+        location: METHOD_CALL
+        pattern: jakarta.persistence.EntityManager.remove*

--- a/resources/rulesets/quarkus/240-jdbc-jpa-mixed-to-quarkus.yaml
+++ b/resources/rulesets/quarkus/240-jdbc-jpa-mixed-to-quarkus.yaml
@@ -1,0 +1,138 @@
+- category: optional
+  customVariables: []
+  description: Mixed JDBC and JPA usage detected
+  effort: 5
+  labels:
+  - konveyor.io/source=java-ee
+  - konveyor.io/source=jakarta-ee
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus Hibernate ORM Guide
+    url: https://quarkus.io/guides/hibernate-orm
+  - title: Quarkus Agroal Datasource Guide
+    url: https://quarkus.io/guides/datasource
+  message: |-
+    This file uses both JPA (EntityManager) and direct JDBC (PreparedStatement).
+    Consider using JPA/JPQL consistently for better code maintainability and portability.
+
+    Benefits of using JPA consistently:
+    - Better object-relational mapping
+    - Database vendor independence
+    - Easier transaction management
+    - Type-safe queries with Criteria API or Panache
+
+    If you need direct JDBC for specific performance reasons or complex queries,
+    consider using Quarkus Panache which provides a simplified JPA experience:
+    ```java
+    // Instead of direct JDBC
+    // Use Panache Active Record pattern
+    public class MyEntity extends PanacheEntity {
+        public String name;
+
+        public static List<MyEntity> findByName(String name) {
+            return find("name", name).list();
+        }
+    }
+    ```
+
+    Or use native queries in JPA when needed:
+    ```java
+    @Inject
+    EntityManager em;
+
+    public List<MyEntity> complexQuery() {
+        return em.createNativeQuery("SELECT * FROM my_entity WHERE ...", MyEntity.class)
+                 .getResultList();
+    }
+    ```
+  ruleID: jdbc-jpa-mixed-to-quarkus-00001
+  when:
+    and:
+    - java.referenced:
+        location: IMPORT
+        pattern: "*EntityManager"
+      as: hasEntityManager
+    - java.referenced:
+        location: IMPORT
+        pattern: java.sql.PreparedStatement
+        filePaths:
+        - "{{hasEntityManager.filePaths}}"
+- category: optional
+  customVariables: []
+  description: Direct JDBC Connection usage detected
+  effort: 3
+  labels:
+  - konveyor.io/source=java-ee
+  - konveyor.io/source=jakarta-ee
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus Agroal Datasource Guide
+    url: https://quarkus.io/guides/datasource
+  - title: Quarkus Hibernate ORM Guide
+    url: https://quarkus.io/guides/hibernate-orm
+  message: |-
+    Direct JDBC Connection usage detected.
+
+    In Quarkus, if you need to use direct JDBC, inject the AgroalDataSource:
+    ```java
+    import io.agroal.api.AgroalDataSource;
+    import jakarta.inject.Inject;
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    public void query() throws SQLException {
+        try (Connection conn = dataSource.getConnection()) {
+            // Use connection
+        }
+    }
+    ```
+
+    However, consider using JPA/Hibernate or Quarkus Panache for most database operations,
+    as they provide better abstraction and are more idiomatic in Quarkus applications.
+  ruleID: jdbc-jpa-mixed-to-quarkus-00002
+  when:
+    java.referenced:
+      location: IMPORT
+      pattern: java.sql.Connection
+- category: optional
+  customVariables: []
+  description: Statement usage should be reviewed
+  effort: 3
+  labels:
+  - konveyor.io/source=java-ee
+  - konveyor.io/source=jakarta-ee
+  - konveyor.io/target=quarkus
+  links:
+  - title: Quarkus Agroal Datasource Guide
+    url: https://quarkus.io/guides/datasource
+  - title: Quarkus Hibernate ORM Guide
+    url: https://quarkus.io/guides/hibernate-orm
+  message: |-
+    Direct JDBC Statement usage detected.
+
+    Consider migrating to JPA/JPQL or Quarkus Panache for better maintainability.
+    If direct JDBC is required, use PreparedStatement instead of Statement to prevent SQL injection.
+
+    In Quarkus, inject the datasource:
+    ```java
+    import io.agroal.api.AgroalDataSource;
+    import jakarta.inject.Inject;
+
+    @Inject
+    AgroalDataSource dataSource;
+
+    public void query(String param) throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement("SELECT * FROM table WHERE col = ?")) {
+            stmt.setString(1, param);
+            ResultSet rs = stmt.executeQuery();
+            // Process results
+        }
+    }
+    ```
+  ruleID: jdbc-jpa-mixed-to-quarkus-00003
+  when:
+    java.referenced:
+      location: IMPORT
+      pattern: java.sql.Statement

--- a/resources/rulesets/technology-usage/03-web-technology-usage.windup.yaml
+++ b/resources/rulesets/technology-usage/03-web-technology-usage.windup.yaml
@@ -61,9 +61,8 @@
   - Rich=Applet
   - Java EE=Applet
   when:
-    or:
-    - builtin.hasTags:
-      - Applet
+    builtin.hasTags:
+    - Applet
 - customVariables: []
   description: JNLP
   labels:


### PR DESCRIPTION
Update with: https://github.com/konveyor/rulesets/pull/301

Ran:
`make ruleset-patch`
`make run-prepare`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Quarkus migration rules for persistence context replacement
  * Added JNDI-to-Quarkus migration guidance for InitialContext and Context.lookup patterns
  * Added transaction boundary rules for Quarkus EntityManager operations
  * Added mixed JDBC/JPA usage detection with remediation guidance

* **Chores**
  * Updated rule integrity checksums
  * Streamlined rule condition structures for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->