### PR TITLE
Pass matching API tests ref to CI

### DIFF
--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -43,3 +43,4 @@ jobs:
     uses: konveyor/ci/.github/workflows/global-ci-bundle.yml@main
     with:
       tackle_hub: ttl.sh/konveyor-hub-${{ github.sha }}:4h
+      api_tests_ref: ${{ github.event_name == 'push' && github.ref || github.base_ref }}


### PR DESCRIPTION
This should fix running main branch API tests on release-X.Y branches of seeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to improve build and test pipeline handling across different event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->