### PR TITLE
Update .NET description and migration label

### DIFF
--- a/resources/targets.yaml
+++ b/resources/targets.yaml
@@ -167,5 +167,5 @@ items:
       imagepath: images/csharp.svg
       choice: true
       labels:
-        - name: Migration of ASP.NET MVC applications from .NET Framework to ASP.NET Core / .NET Core
+        - name: Migration from .NET Framework to .NET Core
           label: konveyor.io/target=dotnet-core

--- a/resources/targets.yaml
+++ b/resources/targets.yaml
@@ -162,10 +162,10 @@ items:
           label: konveyor.io/target=astro-v5
     - uuid: 75cfa0a7-075e-48f4-9bc9-d4c514457b4f
       name: .NET
-      description: Upgrade your .NET application.
+      description: .NET Core Migration.
       provider: csharp
       imagepath: images/csharp.svg
       choice: true
       labels:
-        - name: .NET Framework to .NET Framework 3
-          label: konveyor.io/target=dotnet3
+        - name: Migration of ASP.NET MVC applications from .NET Framework to ASP.NET Core / .NET Core
+          label: konveyor.io/target=dotnet-core


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the .NET target description to ".NET Core Migration."
  * Adjusted target labeling: removed the legacy ".NET Framework to .NET Framework 3" label and added a "Migration from .NET Framework to .NET Core" label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->