### PR TITLE
Fix build-hub workflow to trigger tackle2-hub image build

### DIFF
--- a/.github/workflows/build-hub.yaml
+++ b/.github/workflows/build-hub.yaml
@@ -4,10 +4,28 @@ on:
   pull_request:
     branches:
       - main
+      - 'release-*'
     types:
       - closed
 
 jobs:
   trigger-hub-build:
     if: github.event.pull_request.merged == true
-    uses: konveyor/tackle2-hub/.github/workflows/march-image-build-push.yml@main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v4
+        with:
+          application_id: ${{ vars.KONVEYOR_BOT_ID }}
+          application_private_key: ${{ secrets.KONVEYOR_BOT_KEY }}
+          revoke_token: 'true'
+          permissions: "actions:write"
+
+      - name: Trigger tackle2-hub image build
+        env:
+          GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
+        run: |
+          gh workflow run march-image-build-push.yml \
+            --repo konveyor/tackle2-hub \
+            --ref ${{ github.base_ref }}

--- a/.github/workflows/build-hub.yaml
+++ b/.github/workflows/build-hub.yaml
@@ -25,7 +25,8 @@ jobs:
       - name: Trigger tackle2-hub image build
         env:
           GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
           gh workflow run march-image-build-push.yml \
             --repo konveyor/tackle2-hub \
-            --ref ${{ github.base_ref }}
+            --ref "$BASE_REF"


### PR DESCRIPTION
## Summary
- Fix broken build-hub workflow that failed because tackle2-seed has no Dockerfile
- Trigger tackle2-hub's `march-image-build-push.yml` via `workflow_dispatch` instead of calling it as a reusable workflow
- Add support for `release-*` branches
- Use Konveyor Bot token for cross-repo permissions

## Root Cause
The previous workflow called `konveyor/tackle2-hub/.github/workflows/march-image-build-push.yml` as a reusable workflow, which runs in the caller's context. Since tackle2-seed has no Dockerfile, it always failed with:
```
Error: stat /home/runner/work/tackle2-seed/tackle2-seed/Dockerfile: no such file or directory
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build workflow configuration to improve build triggering and orchestration processes across development and release branches.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konveyor/tackle2-seed/pull/128)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->