### PR TITLE
Use push in action to use Konveyor secrets

### DIFF
--- a/.github/workflows/build-hub.yaml
+++ b/.github/workflows/build-hub.yaml
@@ -1,16 +1,14 @@
 name: tackle2-hub build to update seed and rules
 
 on:
-  pull_request:
+  push:
     branches:
       - main
       - 'release-*'
-    types:
-      - closed
 
 jobs:
   trigger-hub-build:
-    if: github.event.pull_request.merged == true
+    if: github.repository == 'konveyor/tackle2-seed'
     runs-on: ubuntu-latest
     steps:
       - name: Get Token
@@ -25,8 +23,8 @@ jobs:
       - name: Trigger tackle2-hub image build
         env:
           GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
-          BASE_REF: ${{ github.base_ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           gh workflow run march-image-build-push.yml \
             --repo konveyor/tackle2-hub \
-            --ref "$BASE_REF"
+            --ref "$REF_NAME"

--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -13,6 +13,27 @@ on:
     - 'release-*'
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.get-tag.outputs.tag }}
+    steps:
+      - id: get-tag
+        run: |
+          echo "Get tag for quay.io/konveyor images"      
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            branch="${{ github.ref_name }}"
+          else
+            branch="${{ github.base_ref }}"
+          fi
+
+          if [[ "$branch" == "main" ]]; then
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=$branch" >> "$GITHUB_OUTPUT"
+          fi
+          echo "$(grep tag "$GITHUB_OUTPUT")"
+
   build-hub:
     name: Build tackle2-hub
     runs-on: ubuntu-24.04
@@ -39,8 +60,22 @@ jobs:
         podman push $IMG
 
   e2e:
-    needs: build-hub
+    needs: [setup, build-hub]
     uses: konveyor/ci/.github/workflows/global-ci-bundle.yml@main
     with:
-      tackle_hub: ttl.sh/konveyor-hub-${{ github.sha }}:4h
-      api_tests_ref: ${{ github.event_name == 'push' && github.ref || github.base_ref }}
+      operator_bundle: quay.io/konveyor/tackle2-operator-bundle:${{ needs.setup.outputs.tag }}
+      run_api_tests: false
+      run_koncur_hub_tests: true
+      koncur_ref: ${{ github.event_name == 'push' && github.ref_name || github.base_ref }}
+      tackle_cr: |
+        kind: Tackle
+        apiVersion: tackle.konveyor.io/v1alpha1
+        metadata:
+          name: tackle
+        spec:
+          image_pull_policy: IfNotPresent
+          analyzer_container_requests_cpu: 100m
+          provider_java_container_requests_cpu: 100m
+          provider_python_container_requests_cpu: 100m
+          feature_auth_required: false
+          hub_image_fqin: ttl.sh/konveyor-hub-${{ github.sha }}:4h


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now triggers on pushes to main and release branches instead of pull-request close events.
  * Workflow conditions tightened to run only in the intended repository context.
  * Added a setup step to compute image/deployment tags and pass them into end-to-end jobs.
  * E2E flow updated to run Koncur hub tests using the computed tag and an inline manifest for image naming and resource defaults.
  * Downstream workflow trigger now uses the current branch/ref name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->